### PR TITLE
Save the current value and reload when needed. Needed when the activt…

### DIFF
--- a/ClickMe/ClickMe/MainActivity.cs
+++ b/ClickMe/ClickMe/MainActivity.cs
@@ -14,6 +14,7 @@ namespace ClickMe
         Button btnIncrease, btnDecrease;
         TextView lblValue;
         int Value = 0;
+        const string keyValue = "value";
 
         private void SetupResources()
         {
@@ -43,7 +44,20 @@ namespace ClickMe
             SetContentView(Resource.Layout.Main);
 
             SetupResources();
+
+            if (bundle != null)
+            {
+                Value = bundle.GetInt(keyValue);
+                SetValue(Value);
+            }            
         }
+
+        protected override void OnSaveInstanceState(Bundle outState)
+        {     
+            base.OnSaveInstanceState(outState);
+            outState.PutInt(keyValue, Value);
+        }
+
     }
 }
 


### PR DESCRIPTION
…y changes (rotation)

Had a bit of fun and games with this. Namely, the app wasn't building properly, or it was being partially cached in the emulator, so that the SetupResources function didn't get called in the OnCreate. A restart of visual studio sorted it.
